### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ the environment, and call ImageJ.
 To pass arguments to ImageJ, just specify them on the command line.
 
 To pass arguments to the Java Virtual Machine, specify them on the command
-line, separating them from the ImageJ arguments (if any) with a "--".
+line, separating them from the ImageJ arguments (if any) with a `--`.
 In other words, if you want to override the memory setting, call Fiji
 like this:
 


### PR DESCRIPTION
I noticed you are already using Markdown in your readme, but since it didn't end with .md, GitHub wasn't rendering it properly. Thought this might be helpful.
