### PR TITLE
 Make_Screencast.bsh: also search for VLC at default location on Mac

### DIFF
--- a/plugins/Scripts/File/Make_Screencast.bsh
+++ b/plugins/Scripts/File/Make_Screencast.bsh
@@ -34,6 +34,11 @@ discoverVLC() {
 			if (file.exists())
 				return file.getAbsolutePath();
 		}
+		if (System.getProperty("os.name").startsWith("Mac")) {
+			file = new File("/Applications/VLC.app/Contents/MacOS/", "VLC");
+			if (file.exists())
+				return file.getAbsolutePath();
+		}
 	return null;
 }
 


### PR DESCRIPTION
I just used this helpful script on a Mac and thought it wouldn't hurt looking for VLC in the Applications folder as well.
