### PR TITLE
Update to Correct_3D_drift.py

### DIFF
--- a/plugins/Scripts/Plugins/Registration/Correct_3D_drift.py
+++ b/plugins/Scripts/Plugins/Registration/Correct_3D_drift.py
@@ -203,7 +203,7 @@ def create_registered_hyperstack(imp, channel, target_folder, virtual):
     registeredstack_imp.setProperty("Info", imp.getProperty("Info"))
     registeredstack_imp.setDimensions(imp.getNChannels(), len(names) / (imp.getNChannels() * imp.getNFrames()), imp.getNFrames())
     registeredstack_imp.setOpenAsHyperStack(True)
-    if 1 == registeredstack_imp.getChannels():
+    if 1 == registeredstack_imp.getNChannels():
       return registeredstack_imp
   IJ.log("\nHyperstack dimensions: time frames:" + str(registeredstack_imp.getNFrames()) + ", slices: " + str(registeredstack_imp.getNSlices()) + ", channels: " + str(registeredstack_imp.getNChannels()))
 


### PR DESCRIPTION
I have separated out the improvements to the script into separate commits
1 - added ability and dialog to register hyperstack in RAM rather than writing out as virtual hyperstack
2 - Copy of image information, colour, and properties from original to registered image. 
