### PR TITLE
allow to save matched points and models into the descriptor parameters

### DIFF
--- a/src-plugins/Descriptor_based_registration/src/main/java/plugin/DescriptorParameters.java
+++ b/src-plugins/Descriptor_based_registration/src/main/java/plugin/DescriptorParameters.java
@@ -1,7 +1,11 @@
 package plugin;
 
+import java.util.ArrayList;
+
 import ij.gui.Roi;
 import mpicbg.models.AbstractModel;
+import mpicbg.models.InvertibleBoundable;
+import mpicbg.models.PointMatch;
 import mpicbg.models.TranslationModel2D;
 import mpicbg.models.TranslationModel3D;
 
@@ -95,4 +99,12 @@ public class DescriptorParameters
 			return new TranslationModel3D();
 
 	}
+	
+	// for java-based calling
+	public boolean storePoints = false;
+	public boolean storeModels = false;
+	
+	public ArrayList<PointMatch> inliers = null;
+	public InvertibleBoundable model1 = null;
+	public InvertibleBoundable model2 = null;
 }

--- a/src-plugins/Descriptor_based_registration/src/main/java/process/Matching.java
+++ b/src-plugins/Descriptor_based_registration/src/main/java/process/Matching.java
@@ -130,9 +130,22 @@ public class Matching
 				}
 			}
 			
-			Descriptor_based_registration.lastModel1 = (InvertibleBoundable)model1.copy();
-			Descriptor_based_registration.lastModel2 = (InvertibleBoundable)model2.copy();
-			Descriptor_based_registration.lastDimensionality = params.dimensionality;
+			if ( params.storePoints )
+				params.inliers = finalInliers;
+			
+			if ( params.storeModels )
+			{
+				params.model1 = (InvertibleBoundable)model1.copy();
+				params.model2 = (InvertibleBoundable)model2.copy();
+			}
+
+			try
+			{
+				Descriptor_based_registration.lastModel1 = (InvertibleBoundable)model1.copy();
+				Descriptor_based_registration.lastModel2 = (InvertibleBoundable)model2.copy();
+				Descriptor_based_registration.lastDimensionality = params.dimensionality;
+			}
+			catch ( Exception e ) { IJ.log( "Could not save model as static variable." ); };
 			
 			if ( !params.silent )
 				IJ.log( "" + model1 );


### PR DESCRIPTION
this is a useful addition if the descriptor-based registration is called from within java
