### PR TITLE
Fiji_Plugins: move Rounded_Rectangle to Edit>Selection menu

### DIFF
--- a/src-plugins/Fiji_Plugins/src/main/resources/plugins.config
+++ b/src-plugins/Fiji_Plugins/src/main/resources/plugins.config
@@ -2,7 +2,6 @@
 
 Image>Drawing, "Radial Gradient", fiji.drawing.Radial_Gradient
 Image>Drawing, "Linear Gradient", fiji.drawing.Linear_Gradient
-Image>Selection, "Make rectangular selection rounded", fiji.selection.Rounded_Rectangle
 
 # Radial_Reslice
 Image>Stacks, "Radial Reslice", fiji.stacks.Radial_Reslice
@@ -18,6 +17,7 @@ Edit>Selection, "Fit Circle to Image", fiji.util.Circle_Fitter
 Edit>Selection, "Select Bounding Box", fiji.selection.Select_Bounding_Box
 Edit>Selection, "Select Bounding Box (guess background color)", fiji.selection.Select_Bounding_Box("autoselect")
 Edit>Selection, "Points from Mask", fiji.selection.Binary_to_Point_Selection
+Edit>Selection, "Make rectangular selection rounded", fiji.selection.Rounded_Rectangle
 
 Plugins>Utilities, "Repeat a Recent Command", fiji.util.Recent_Commands
 


### PR DESCRIPTION
Hi, the presence of two _Selection_ submenus (Edit>Selection and Image>Selection) is a little confusing to some users, so I moved the _single_ entry "Make rectangular selection rounded" into the other submenu in the hope to decrease menu clutter.

Cheers,
Jan
