### PR TITLE
Save Script Editor preferences

### DIFF
--- a/src-plugins/Script_Editor/src/main/java/fiji/scripting/TextEditor.java
+++ b/src-plugins/Script_Editor/src/main/java/fiji/scripting/TextEditor.java
@@ -1218,8 +1218,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		 * Loads the preferences for the Tab from ij.Prefs and apply them.
 		 */
 		public void loadPreferences() {
-			editorPane.setTabSize((int) Prefs.get(TAB_SIZE_PREFS,
-				DEFAULT_TAB_SIZE));
+			editorPane.setTabSize(getTabSizeSetting());
 			editorPane.setFontSize((int) Prefs.get(FONT_SIZE_PREFS,
 				editorPane.getFontSize()));
 			editorPane.setLineWrap(Prefs.get(LINE_WRAP_PREFS,
@@ -1767,8 +1766,10 @@ public class TextEditor extends JFrame implements ActionListener,
 	protected void updateTabAndFontSize(boolean setByLanguage) {
 		EditorPane pane = getEditorPane();
 
-//		if (setByLanguage)
-//			pane.setTabSize(pane.currentLanguage.menuLabel.equals("Python") ? 4 : 8);
+		if (setByLanguage) {
+			final boolean isPython = pane.currentLanguage.menuLabel.equals("Python");
+			pane.setTabSize(isPython ? 4 : getTabSizeSetting());
+		}
 
 		int tabSize = pane.getTabSize();
 		boolean defaultSize = false;
@@ -2349,4 +2350,9 @@ public class TextEditor extends JFrame implements ActionListener,
 		JOptionPane.showMessageDialog(this, msg);
 		return count;
 	}
+
+	private int getTabSizeSetting() {
+		return (int) Prefs.get(TAB_SIZE_PREFS, DEFAULT_TAB_SIZE);
+	}
+
 }


### PR DESCRIPTION
This updates the Fiji Script Editor to save and restore preferences for a few things, including tab size, font size, line wrap, emulated tabs and window size. It is largely the work of @sinverso, rebased to fix some whitespace issues.

I also restored the language-specific tab size behavior, in particular for Python which resets to tab size 4 every time that Python is selected as the language, or a Python script is opened. While this behavior may not be completely ideal (I agree with @dscho that ideally, the tab size would simply be persisted per-language), the current approach will suffice for now, in the interest of getting these improvements merged quickly.
