### PR TITLE
Use the shiny new Sholl Analysis version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
 	<properties>
 		<SPIM_Registration.version>2.0.0-SNAPSHOT</SPIM_Registration.version>
-		<Sholl_Analysis.version>3.0.0-SNAPSHOT</Sholl_Analysis.version>
+		<Sholl_Analysis.version>3.4.0</Sholl_Analysis.version>
 		<Stitching.version>2.0.0-SNAPSHOT</Stitching.version>
 		<TrackMate.version>2.1.1-SNAPSHOT</TrackMate.version>
 		<autocomplete.version>2.0.2</autocomplete.version>


### PR DESCRIPTION
This is one of the many steps in the direction of reproducible Fiji
builds (i.e. having only defined release versions as dependencies).

It relies on https://github.com/tferr/ASA/pull/2 being merged, first.
Once merged, it will address https://github.com/fiji/fiji/issues/66.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
