### PR TITLE
Fix VerifyError when running Register Virtual Stack in headless mode

### DIFF
--- a/src-plugins/register_virtual_stack_slices/src/main/java/register_virtual_stack/Register_Virtual_Stack_MT.java
+++ b/src-plugins/register_virtual_stack_slices/src/main/java/register_virtual_stack/Register_Virtual_Stack_MT.java
@@ -243,7 +243,7 @@ public class Register_Virtual_Stack_MT implements PlugIn
 			chooser.setDialogTitle("Choose directory to store Transform files");
 			chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 			chooser.setAcceptAllFileFilterUsed(true);
-			if (chooser.showOpenDialog(gd) != JFileChooser.APPROVE_OPTION)
+			if (chooser.showOpenDialog(null) != JFileChooser.APPROVE_OPTION)
 		    	return;
 			
 			save_dir = chooser.getSelectedFile().toString();
@@ -262,7 +262,7 @@ public class Register_Virtual_Stack_MT implements PlugIn
 			chooser.setDialogTitle("Choose reference image");
 			chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
 			chooser.setAcceptAllFileFilterUsed(true);
-			if (chooser.showOpenDialog(gd) != JFileChooser.APPROVE_OPTION)
+			if (chooser.showOpenDialog(null) != JFileChooser.APPROVE_OPTION)
 				return;
 			referenceName = chooser.getSelectedFile().getName();
 		}


### PR DESCRIPTION
In headless mode, we must avoid instantiating any classes related to font
display because they require a GUI.

As such, we actually cannot instantiate any AWT dialog. Unfortunately,
ImageJ 1.x' design _forces_ the use of AWT dialogs when recording or
replaying macros.

For that reason, we had to hack ImageJ 1.x in headless mode to rewrite the
class hierarchy so that the GenericDialog class no longer inherits from
the AWT Dialog class.

Register Virtual Stack completely ignored these issues and used the
GenericDialog as a parent window when showing the JFileChooser. This must
break because the parent window of a JFileChooser must be an AWT component
and as explained above, the GenericDialog cannot be such a component in
headless mode.

As a quick workaround, do not use a specific parent window for the
JFileChooser.

The proper fix, of course, is to use GenericDialogPlus' addFile() method,
but that task will have to be performed by another developer.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
