### PR TITLE
Allow JavaScript for startup macros as well.

### DIFF
--- a/macros/AutoRun/AutoRun_JavaScript.ijm
+++ b/macros/AutoRun/AutoRun_JavaScript.ijm
@@ -1,5 +1,5 @@
 // run all the .js scripts provided in /plugins/Scripts/Plugins/AutoRun/
-autoRunDirectory = getDirectory("imagej") + "plugins/Scripts/Plugins/AutoRun/";
+autoRunDirectory = getDirectory("imagej") + "/plugins/Scripts/Plugins/AutoRun/";
 if (File.isDirectory(autoRunDirectory)) {
     list = getFileList(autoRunDirectory);
     // make sure startup order is consistent

--- a/macros/AutoRun/AutoRun_JavaScript.ijm
+++ b/macros/AutoRun/AutoRun_JavaScript.ijm
@@ -1,0 +1,13 @@
+// run all the .js scripts provided in /plugins/Scripts/Plugins/AutoRun/
+autoRunDirectory = getDirectory("imagej") + "plugins/Scripts/Plugins/AutoRun/";
+if (File.isDirectory(autoRunDirectory)) {
+    list = getFileList(autoRunDirectory);
+    // make sure startup order is consistent
+    Array.sort(list);
+    for (i = 0; i < list.length; i++) {
+        if (endsWith(list[i], ".js")) {
+            runMacro(autoRunDirectory + list[i]);
+        }
+    }
+}
+

--- a/macros/StartupMacros.fiji.ijm
+++ b/macros/StartupMacros.fiji.ijm
@@ -53,7 +53,7 @@ macro "AutoRun" {
 		// make sure startup order is consistent
 		Array.sort(list);
 		for (i = 0; i < list.length; i++) {
-			if (endsWith(list[i], ".ijm") || endsWith(list[i], ".js")) {
+			if (endsWith(list[i], ".ijm")) {
 				runMacro(autoRunDirectory + list[i]);
 			}
 		}

--- a/macros/StartupMacros.fiji.ijm
+++ b/macros/StartupMacros.fiji.ijm
@@ -53,7 +53,7 @@ macro "AutoRun" {
 		// make sure startup order is consistent
 		Array.sort(list);
 		for (i = 0; i < list.length; i++) {
-			if (endsWith(list[i], ".ijm")) {
+			if (endsWith(list[i], ".ijm") || endsWith(list[i], ".js")) {
 				runMacro(autoRunDirectory + list[i]);
 			}
 		}


### PR DESCRIPTION
Unless there is a specific reason not to do so, it would be very handy to allow for JavaScript in the startup macros folder as well (currently only ".ijm" is allowed). Successfully tested on my Fiji here.

Cheers
~Niko