### PR TITLE
Update Miji.m

### DIFF
--- a/scripts/Miji.m
+++ b/scripts/Miji.m
@@ -1,4 +1,4 @@
-function Miji(open_imagej)
+function [mij] = Miji(open_imagej)
     %% This script sets up the classpath to Fiji and optionally starts MIJ
     % Author: Jacques Pecreaux, Johannes Schindelin, Jean-Yves Tinevez
 
@@ -18,8 +18,8 @@ function Miji(open_imagej)
     % Switch off warning
     warning_state = warning('off');
     
-    add_to_classpath(classpath, fullfile(fiji_directory,'jars'));
-    add_to_classpath(classpath, fullfile(fiji_directory,'plugins'));
+    add_to_classpath(classpath, strcat([fiji_directory filesep 'jars']));
+    add_to_classpath(classpath, strcat([fiji_directory filesep 'plugins']));
     
     % Switch warning back to initial settings
     warning(warning_state)
@@ -32,7 +32,9 @@ function Miji(open_imagej)
     if open_imagej
         cd ..;
         fprintf('\n\nUse MIJ.exit to end the session\n\n');
-        MIJ.start();
+        % EB change May 2015
+        mij = MIJ;
+        mij.start();
     else
         % initialize ImageJ with the NO_SHOW flag (== 2)
         ij.ImageJ([], 2);
@@ -48,33 +50,24 @@ function Miji(open_imagej)
     % mess on Windows platform.
     % So we give it up as now.
     % %    fiji.User_Plugins.installScripts();
+    
+    
+    
 end
 
 function add_to_classpath(classpath, directory)
     % Get all .jar files in the directory
-    dirData = dir(directory);
-    dirIndex = [dirData.isdir];
-    jarlist = dir(fullfile(directory,'*.jar'));
+    test = dir(strcat([directory filesep '*.jar']));
     path_= cell(0);
-    for i = 1:length(jarlist)
-      disp(jarlist(i).name);
-        if not_yet_in_classpath(classpath, jarlist(i).name)
-            path_{length(path_) + 1} = fullfile(directory,jarlist(i).name);
+    for i = 1:length(test)
+        if not_yet_in_classpath(classpath, test(i).name)
+            path_{length(path_) + 1} = strcat([directory filesep test(i).name]);
         end
     end
 
     %% Add them to the classpath
     if ~isempty(path_)
         javaaddpath(path_, '-end');
-    end
-
-    %# Recurse over subdirectories
-    subDirs = {dirData(dirIndex).name};
-    validIndex = ~ismember(subDirs,{'.','..'});
-
-    for iDir = find(validIndex)
-      nextDir = fullfile(directory,subDirs{iDir});
-      add_to_classpath(classpath, nextDir);
     end
 end
 


### PR DESCRIPTION
This proposed change removes a bug I described on imagej-dev . Any other use of javaaddpath, say to develop one's other software, loses the instance of MIJ. This is because javaaddpath automatically calls clear java. By returning the MIJ instance as a workspace object, the MIJ instance will not be cleared. The only change for the user is to call:

MIJ = Miji;

instead of just 

Miji;