### PR TITLE
Update build script for newer environment (MSYS2), fixes OS bitness detection

### DIFF
--- a/Build.sh
+++ b/Build.sh
@@ -73,13 +73,15 @@ Linux)
 	FIJILAUNCHER=fiji-$platform
 	FIJILAUNCHER=${FIJILAUNCHER%32}
 	;;
-MINGW*|CYGWIN*)
+MINGW*|CYGWIN*|MSYS*)
 	CWD="$(cd "$CWD" && pwd)"
 	PATHSEP=\;
-	case "$PROCESSOR_ARCHITEW6432" in
-	'') platform=win32; java_submodule=$platform;;
-	*) platform=win64; java_submodule=$platform;;
-	esac
+	if [ "$PROCESSOR_ARCHITECTURE" = "AMD64" ] || [ "$PROCESSOR_ARCHITEW6432" = "AMD64" ];  then
+		platform=win64
+	else
+		platform=win32
+	fi
+	java_submodule=$platform
 	exe=.exe
 	LAUNCHER=ImageJ-$platform.exe
 	FIJILAUNCHER=fiji-$platform.exe


### PR DESCRIPTION
With recent version of Git for windows (2.5+) or MSYS2, uname -s outputs "MSYS_NT-6.1",
which isn't recognized by Build.sh as Windows platform. Also, now that process can be 64
bit, detection of bitness must be more accurate and follow  detection logic explained here:
http://blogs.msdn.com/b/david.wang/archive/2006/03/26/howto-detect-process-bitness.aspx