### PR TITLE
Fixing the multithread example to run with nashorn on Java 8:

### DIFF
--- a/plugins/Examples/Multithreaded_Image_Processing_in_Javascript.js
+++ b/plugins/Examples/Multithreaded_Image_Processing_in_Javascript.js
@@ -38,7 +38,7 @@ importClass(Packages.java.util.concurrent.atomic.AtomicInteger);
 
 // Print all numbers from start to end (inclusive), multithreaded
 function doItMultithreaded(start, end) {
-	var threads = new java.lang.reflect.Array.newInstance(java.lang.Thread, Runtime.getRuntime().availableProcessors());
+	var threads = java.lang.reflect.Array.newInstance(java.lang.Thread.class, Runtime.getRuntime().availableProcessors());
 	var ai = new AtomicInteger(start);
 	var body = {
 		run: function() {
@@ -65,7 +65,7 @@ function doItMultithreaded(start, end) {
 // Now, abstract away the multithreading framework into a function
 // that takes another function as argument:
 function multithreader(fun, start, end) {
-	var threads = new java.lang.reflect.Array.newInstance(java.lang.Thread, Runtime.getRuntime().availableProcessors());
+	var threads = java.lang.reflect.Array.newInstance(java.lang.Thread.class, Runtime.getRuntime().availableProcessors());
 	var ai = new AtomicInteger(start);
 	// Prepare arguments: all other arguments passed to this function
 	// beyond the mandatory arguments fun, start and end:


### PR DESCRIPTION
The first problem was
> Java method [jdk.internal.dynalink.beans.OverloadedDynamicMethod java.lang.reflect.Array.newInstance] cannot be used as a constructor.
Removing the new fixes this problem, but a new problem arises:
> java.lang.NoSuchMethodException: None of the fixed arity signatures [(java.lang.Class, int), (java.lang.Class, int[])] or the variable arity signatures [(java.lang.Class, int...)] of the method java.lang.reflect.Array.newInstance match the argument types [jdk.internal.dynalink.beans.StaticClass, java.lang.Integer]
Adding ``.class`` to ``java.lang.Thread`` fixed this.