### PR TITLE
Miji: Add a verbose flag, stay in same directory

### DIFF
--- a/scripts/Miji.m
+++ b/scripts/Miji.m
@@ -1,4 +1,4 @@
-function [mij] = Miji(open_imagej)
+function [mij] = Miji(open_imagej, verbose)
     %% This script sets up the classpath to Fiji and optionally starts MIJ
     % Author: Jacques Pecreaux, Johannes Schindelin, Jean-Yves Tinevez
 
@@ -6,6 +6,9 @@ function [mij] = Miji(open_imagej)
         open_imagej = true;
     end
     
+    if nargin < 2
+        verbose = false;
+    end
 
     %% Get the Fiji directory
     fiji_directory = fileparts(fileparts(mfilename('fullpath')));
@@ -16,10 +19,10 @@ function [mij] = Miji(open_imagej)
     %% Add all libraries in jars/ and plugins/ to the classpath
     
     % Switch off warning
-    warning_state = warning('off');
+    warning_state = warning('off','MATLAB:javaclasspath:jarAlreadySpecified');
     
-    add_to_classpath(classpath, fullfile(fiji_directory,'jars'));
-    add_to_classpath(classpath, fullfile(fiji_directory,'plugins'));
+    add_to_classpath(classpath, fullfile(fiji_directory,'jars'), verbose);
+    add_to_classpath(classpath, fullfile(fiji_directory,'plugins'), verbose);
     
     % Switch warning back to initial settings
     warning(warning_state)
@@ -30,7 +33,6 @@ function [mij] = Miji(open_imagej)
 
     %% Maybe open the ImageJ window
     if open_imagej
-        cd ..;
         fprintf('\n\nUse MIJ.exit to end the session\n\n');
         % EB change May 2015
         mij = MIJ;
@@ -52,15 +54,17 @@ function [mij] = Miji(open_imagej)
     % %    fiji.User_Plugins.installScripts();
 end
 
-function add_to_classpath(classpath, directory)
+function add_to_classpath(classpath, directory, verbose)
     % Get all .jar files in the directory
     dirData = dir(directory);
     dirIndex = [dirData.isdir];
     jarlist = dir(fullfile(directory,'*.jar'));
     path_= cell(0);
     for i = 1:length(jarlist)
-      disp(jarlist(i).name);
         if not_yet_in_classpath(classpath, jarlist(i).name)
+            if verbose
+                disp(strcat(['Adding: ',jarlist(i).name]));
+            end
             path_{length(path_) + 1} = fullfile(directory,jarlist(i).name);
         end
     end
@@ -76,7 +80,7 @@ function add_to_classpath(classpath, directory)
 
     for iDir = find(validIndex)
       nextDir = fullfile(directory,subDirs{iDir});
-      add_to_classpath(classpath, nextDir);
+      add_to_classpath(classpath, nextDir, verbose);
     end
 end
 


### PR DESCRIPTION
- Avoid command prompt spam of printing every artifact added to the classpath to the console (default: false). Related commit: imagej/imagej-matlab@2633d12c744e0d636cfe698edf4a53c471fd56d4 
- Remove `cd ..` to stay in the same directory while loading Miji
- Only turn warnings off for: `MATLAB:javaclasspath:jarAlreadySpecified`
