### PR TITLE
Adding a batch mode option to the Temporal-Color Coder Macro

### DIFF
--- a/plugins/Scripts/Image/Hyperstacks/Temporal-Color_Code.ijm
+++ b/plugins/Scripts/Image/Hyperstacks/Temporal-Color_Code.ijm
@@ -34,6 +34,7 @@ var Glut = "Fire";	//default LUT
 var Gstartf = 1;
 var Gendf = 10;
 var GFrameColorScaleCheck = 1;
+var GbatchMode = 0;
 
 macro "Time-Lapse Color Coder" {
 	Stack.getDimensions(ww, hh, channels, slices, frames);
@@ -128,7 +129,9 @@ macro "Time-Lapse Color Coder" {
 	close();
 
 	selectImage(resultImageID);
-	setBatchMode("exit and display");
+	
+	if (GbatchMode == 0)
+		setBatchMode("exit and display");
 
 	if (GFrameColorScaleCheck)
 		CreateScale(Glut, Gstartf, Gendf);
@@ -179,11 +182,13 @@ function showDialog() {
 	Dialog.addNumber("start frame", Gstartf);
 	Dialog.addNumber("end frame", Gendf);
 	Dialog.addCheckbox("Create Time Color Scale Bar", GFrameColorScaleCheck);
+	Dialog.addCheckbox("Batch mode? (no image output)", GbatchMode);
 	Dialog.show();
  	Glut = Dialog.getChoice();
 	Gstartf = Dialog.getNumber();
 	Gendf = Dialog.getNumber();
 	GFrameColorScaleCheck = Dialog.getCheckbox();
+	GbatchMode = Dialog.getCheckbox();
 }
 
 function CreateScale(lutstr, beginf, endf){


### PR DESCRIPTION
The setBatchMode("exit and display"); command on line 131 conflicts with setBatchMode(true); commands when the temporal color coder Macro is called from other macros with the imageJ run() command.

Example problem scenario: 

setBatchMode(true);
run("Temporal-Color Code", "lut=Spectrum start=1 end=34"); //Running the current version of the macro will fail to suppress output

Solution: 

Include an optional batchMode variable that can be passed via the run() command:

Example:

setBatchMode(true);
run("Temporal-Color Code", "lut=Spectrum start=1 end=34 batch"); //output will be properly suppressed