### PR TITLE
D:\Dropbox\Private_Dropbox\Projects\Fiji\scripts\copytoImgPlus.m

### DIFF
--- a/scripts/copytoImgPlus.m
+++ b/scripts/copytoImgPlus.m
@@ -51,11 +51,11 @@ DEFAULT_AXES = { 'X', 'Y', 'Z', 'T', 'C' };
 
 try
     MATCHING_AXES = [
-        net.imglib2.meta.Axes.X
-        net.imglib2.meta.Axes.Y
-        net.imglib2.meta.Axes.Z
-        net.imglib2.meta.Axes.TIME
-        net.imglib2.meta.Axes.CHANNEL ];
+        net.imagej.axis.Axes.X
+        net.imagej.axis.Axes.Y
+        net.imagej.axis.Axes.Z
+        net.imagej.axis.Axes.TIME
+        net.imagej.axis.Axes.CHANNEL ];
 catch merr
     if strcmp(merr.identifier, 'MATLAB:undefinedVarOrClass')
         error('MATLAB:copytoImgPlus:undefinedVarOrClass', ...
@@ -133,6 +133,6 @@ end
 
 img = copytoImg(I);
 
-imgplus = net.imglib2.img.ImgPlus(img, name, ax, calibration);
+imgplus = net.imagej.ImgPlus(img, name, ax, calibration);
 
 end


### PR DESCRIPTION
This pull request fixes a bug in `copytoImgPlus.m`

The bug was caused by recent changes in Java class tree.

The class names were fixed and the new code passed a simple test

```matlab
A = rand(200,300);
imgplus = copytoImgPlus(A)
```


This problem has been discussed below:

http://forum.imagej.net/t/copytoimgplus-m-does-not-work-properly/11762/2

https://github.com/fiji/fiji/issues/188