### PR TITLE
Copyto image plus

### DIFF
--- a/scripts/copytoImagePlus.m
+++ b/scripts/copytoImagePlus.m
@@ -236,10 +236,16 @@ imp.setDisplayMode(ij.IJ.COLOR) %NOTE this is required to enable the next line
 imp.setDisplayMode(ij.IJ.COMPOSITE)
 
 try
-    imp.resetDisplayRanges();
+    if imp.isComposite
+        imp.resetDisplayRanges(); % only for compsite
+    else
+        imp.resetDisplayRange();
+    end
 catch mexc
     if strcmpi(mexc.identifier,'MATLAB:UndefinedFunction')
-        warning('resetDisplayRanges did not work')
+      
+        warning('resetDisplayRanges did not work') %TODO
+
     else
         throw(mexc)
     end

--- a/scripts/copytoImagePlus.m
+++ b/scripts/copytoImagePlus.m
@@ -61,14 +61,9 @@ function imp = copytoImagePlus(I,varargin)
 % 03-May-2018 04:57:24
 %
 % See also
-% ijmshow (this requires a net.imagej.matlab.ImageJMATLABCommands object IJM)
-% https://github.com/kouichi-c-nakamura/ijmshow (repository for this function)
-%
 % ImageJ as part of ImageJ-MATLAB (https://github.com/imagej/imagej-matlab/)
-%
-% net.imagej.matlab.ImageJMATLABCommands
-% evalin, assignin
-% https://imagej.net/MATLAB_Scripting
+% copytoImgPlus
+% copytoImg, copytoMatlab
 
 
 import ij.process.ShortProcessor

--- a/scripts/copytoImagePlus.m
+++ b/scripts/copytoImagePlus.m
@@ -244,7 +244,7 @@ try
 catch mexc
     if strcmpi(mexc.identifier,'MATLAB:UndefinedFunction')
       
-        warning('resetDisplayRanges did not work') %TODO
+        warning('resetDisplayRanges did not work')
 
     else
         throw(mexc)


### PR DESCRIPTION
`copyToImagePlus` now uses `imp.resetDisplayRanges()` only for a Composite image and otherwise uses `resetDisplayRange()` without `s`. This will much reduce warning.

I might have messed up the version history a bit. I did rebase this branch to the latest `master`, but the branch tree now looks a bit strange. Sorry, if that was wrong. If it's bad, I can redo the forking from scratch, I guess. 

```matlab
try
    if imp.isComposite
        imp.resetDisplayRanges(); % only for compsite
    else
        imp.resetDisplayRange();
    end
catch mexc
    if strcmpi(mexc.identifier,'MATLAB:UndefinedFunction')
      
        warning('resetDisplayRanges did not work') %TODO

    else
        throw(mexc)
    end
end
```