### PR TITLE
POM: add Kappa

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -421,6 +421,11 @@
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
+			<artifactId>Kappa</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
 			<artifactId>Kuwahara_Filter</artifactId>
 			<scope>runtime</scope>
 		</dependency>


### PR DESCRIPTION
This requires a new release of `sc.fiji:Kappa`, and `pom-scijava` to be updated to point to `Kappa-2.0.1`, as there were problems with the 2.0.0 release being deployed to maven.scijava.org (see also https://github.com/fiji/Kappa/issues/6#issuecomment-692762870).

