### PR TITLE
Add mainClass property for exec:java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -904,4 +904,23 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<mainClass>sc.fiji.Main</mainClass>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Currently to start FIJI, one would need to execute:

```
mvn exec:java -Dexec.mainClass="sc.fiji.Main"
```

This branch allows fiji to be started via 

```
mvn exec:java
```

See https://www.mojohaus.org/exec-maven-plugin/usage.html