### PR TITLE
Update The_Hue_Game.bsh to resolve java.security.PrivilegedActionException

### DIFF
--- a/plugins/Examples/The_Hue_Game.bsh
+++ b/plugins/Examples/The_Hue_Game.bsh
@@ -28,7 +28,8 @@ import java.util.Random;
 import stitching.CommonFunctions;
 
 class Rainbow {
-	protected int[] rainbow, indices;
+	protected int[] rainbow;
+	public int[] indices;
 
 	public Rainbow(float l, float a0, float b0, float a1, float b1, int n) {
 		rainbow = new int[n];


### PR DESCRIPTION
Resolves a privledgeAccessException when double clicking to show score (tested with Fiji 2.14.0/1.54f on MacOS 13.5)