### PR TITLE
Temporal Color Code: Add standard deviation projection

### DIFF
--- a/scripts/Image/Hyperstacks/Temporal-Color_Code.ijm
+++ b/scripts/Image/Hyperstacks/Temporal-Color_Code.ijm
@@ -15,6 +15,7 @@ If you publish a paper using this macro, please acknowledge.
 2. Run the macro
 3. In the dialog choose one of the LUT for time coding.
 	select frame range (default is full).
+	select the projection method (maximum intensity is the default projection).
 	check if you want to have color scale bar.
 
 History
@@ -28,7 +29,7 @@ History
 101122  plugin'ified it
 101123	fixed for cases when slices > 1 and frames == 1
 191025  fixed LUT listing by making use of the getList("LUTs") function
-201215  added Standard Deviation option under Max projection methods
+210113  added all the stack projection methods as Max Intensity was the only option earlier
 *****************************************************************************
 */
 
@@ -141,12 +142,12 @@ macro "Time-Lapse Color Coder" {
 
 function showDialog() {
 	lutA = getList("LUTs");
-	projection = newArray("Max Intensity","Standard Deviation"); //new array for maximum projection methods
+	projection = newArray("Average Intensity","Max Intensity","Min Intensity","Sum Slices","Standard Deviation","Median"); //new array for different projection methods supported by ZProjector
  	Dialog.create("Color Code Settings");
 	Dialog.addChoice("LUT", lutA);
 	Dialog.addNumber("start frame", Gstartf);
 	Dialog.addNumber("end frame", Gendf);
-	Dialog.addChoice("Maximum Projection", projection);
+	Dialog.addChoice("Projection Method", projection,"Max Intensity"); //default projection method is max intensity
 	Dialog.addCheckbox("Create Time Color Scale Bar", GFrameColorScaleCheck);
 	Dialog.addCheckbox("Batch mode? (no image output)", GbatchMode);
 	Dialog.show();

--- a/scripts/Image/Hyperstacks/Temporal-Color_Code.ijm
+++ b/scripts/Image/Hyperstacks/Temporal-Color_Code.ijm
@@ -28,6 +28,7 @@ History
 101122  plugin'ified it
 101123	fixed for cases when slices > 1 and frames == 1
 191025  fixed LUT listing by making use of the getList("LUTs") function
+201215  added Standard Deviation option under Max projection methods
 *****************************************************************************
 */
 
@@ -36,7 +37,7 @@ var Gstartf = 1;
 var Gendf = 10;
 var GFrameColorScaleCheck = 1;
 var GbatchMode = 0;
-
+var Z_proj="Max Intensity"; //default maximum projection method
 macro "Time-Lapse Color Coder" {
 	Stack.getDimensions(ww, hh, channels, slices, frames);
 	if (channels > 1)
@@ -119,7 +120,7 @@ macro "Time-Lapse Color Coder" {
 
 	run("Stack to Hyperstack...", "order=xyctz channels=1 slices="
 		+ totalframes + " frames=" + slices + " display=Color");
-	op = "start=1 stop=" + Gendf + " projection=[Max Intensity] all";
+	op = "start=1 stop=" + Gendf + " projection=[" + Z_proj + "] all";
 	run("Z Project...", op);
 	if (slices > 1)
 		run("Stack to Hyperstack...", "order=xyczt(default) channels=1 slices=" + slices
@@ -140,16 +141,19 @@ macro "Time-Lapse Color Coder" {
 
 function showDialog() {
 	lutA = getList("LUTs");
+	projection = newArray("Max Intensity","Standard Deviation"); //new array for maximum projection methods
  	Dialog.create("Color Code Settings");
 	Dialog.addChoice("LUT", lutA);
 	Dialog.addNumber("start frame", Gstartf);
 	Dialog.addNumber("end frame", Gendf);
+	Dialog.addChoice("Maximum Projection", projection);
 	Dialog.addCheckbox("Create Time Color Scale Bar", GFrameColorScaleCheck);
 	Dialog.addCheckbox("Batch mode? (no image output)", GbatchMode);
 	Dialog.show();
  	Glut = Dialog.getChoice();
 	Gstartf = Dialog.getNumber();
 	Gendf = Dialog.getNumber();
+	Z_proj=Dialog.getChoice(); 
 	GFrameColorScaleCheck = Dialog.getCheckbox();
 	GbatchMode = Dialog.getCheckbox();
 }


### PR DESCRIPTION
Resubmission of #276 rebased over the latest main branch.

@pr4deepr wrote:

> Added Standard deviation option under maximum projection methods. This is particularly useful for timeseries experiments. Standard deviation option ensures pixels with large changes in intensity are brighter and thus enhanced in the final image with the temporal colour code overlaid. This is particularly useful if there is a lot of background or if surrounding objects are brighter.
